### PR TITLE
03 2019 production fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 .env
 *.swp
+.env.example1
+.env-prod
+.env-stag

--- a/getGuestImage.js
+++ b/getGuestImage.js
@@ -65,8 +65,12 @@ function getImage(content) {
 }
 
 function splitContent(content) {
-  const splitFrom = content.search("<p><img");
-  const splitTo = content.search("</p>");
-  var result = content.slice(splitFrom, splitTo);
+  let contentToSplit = content
+  if (contentToSplit.startsWith("</p>")) {
+    contentToSplit = contentToSplit.substr(4);
+  }
+  const splitFrom = contentToSplit.search("<p><img");
+  const splitTo = contentToSplit.search("</p>");
+  var result = contentToSplit.slice(splitFrom, splitTo);
   return result
 }

--- a/getTranscriptURL.js
+++ b/getTranscriptURL.js
@@ -40,6 +40,14 @@ posts.find({transcriptURL: {$exists: false}})
           break;
         }
       }
+
+      if (!transcriptURL) {
+        return posts.update({id: post.id}, {
+          $set: {
+            "transcriptURL": null
+          },
+        });
+      }
     });
     console.log(postsCount);
   })


### PR DESCRIPTION
Added two improvements:

1. `getTranscriptURL.js` script will set: `transcriptURL: null` in the post if TranscriptURL was not found. It should speed up processing the posts table.

2. `getGuestImage`: CleanedDecription field in post table can start with `<p><img ..>` or `</p><p><img ..>`. Previously, script worked only for the first case. Fix makes that it sohuld work in both cases.