### PR TITLE
Add time condition to set transcriptURL as null, add process.exit

### DIFF
--- a/getTranscriptURL.js
+++ b/getTranscriptURL.js
@@ -10,17 +10,21 @@ const db = require('monk')(process.env.MONGO_DB)
 const posts = db.get('posts')
 const Bluebird = require('bluebird');
 const getUrls = require('get-urls');
-const request = require("request");
+const rp = require("request-promise");
+const moment = require("moment");
+
+const SET_NULL_AFTER_DAYS = 30; // The number of days after script sets transcript URL to null if not set yet
 
 let promises = [];
-let postsCount = 0
+let postsCount = 0;
 posts.find({transcriptURL: {$exists: false}})
   .each((post) => {
     postsCount++
 
-    request({
-      uri: post.link,
-    }, function(error, response, body) {
+    date_now = moment.utc();
+
+    let requestPromise = rp(post.link)
+    .then(async function(body) {
       const urls = getUrls(body);
       let values = urls.values();
 
@@ -32,7 +36,7 @@ posts.find({transcriptURL: {$exists: false}})
           transcriptURL = url;
           console.log(transcriptURL);
 
-          return posts.update({id: post.id}, {
+          await posts.update({id: post.id}, {
             $set: {
               "transcriptURL": transcriptURL
             },
@@ -42,13 +46,31 @@ posts.find({transcriptURL: {$exists: false}})
       }
 
       if (!transcriptURL) {
-        return posts.update({id: post.id}, {
-          $set: {
-            "transcriptURL": null
-          },
-        });
+        time_diff = date_now.diff(moment(post.date), 'days')
+        if (time_diff > SET_NULL_AFTER_DAYS) {
+          await posts.update({id: post.id}, {
+            $set: {
+              "transcriptURL": null
+            },
+          });
+        }
       }
-    });
+    })
+    .catch((error) => {
+      if (error.statusCode !== 429 && error.statusCode !== 504) {
+        console.log('Error', error)
+      }
+    })
+
+    promises.push(requestPromise);
     console.log(postsCount);
+  })
+  .then(() => {
+    console.log('BLUEBIRD')
+    return Bluebird.all(promises);
+  })
+  .then(() => {
+    console.log("done");
+    process.exit();
   })
   .catch((error) => { console.log(error); })


### PR DESCRIPTION
Transcript URL will set as `null` if for the last 30 days link to the transcript was not found on the Wordpress's post page.

This time limit can be changed by setting `SET_NULL_AFTER_DAYS` value expressed in the number of days.

Switched also from `request` to `request-promise` supporting the Bluebird and added the `process.exit()` so the script's process should end automatically.